### PR TITLE
v2

### DIFF
--- a/src/main/applyVariable.ts
+++ b/src/main/applyVariable.ts
@@ -1,4 +1,4 @@
-import { getAncestorInstances } from '@/main/util'
+import { applyVariableToTextNode } from '@/main/applyVariableToTextNode'
 
 export default async function applyVariable(variable: VariableForUI) {
   console.log('applyVariable', applyVariable)
@@ -41,36 +41,7 @@ export default async function applyVariable(variable: VariableForUI) {
         return
       }
 
-      // 先祖インスタンスを取得
-      const ancestorInstances = await getAncestorInstances(textNode)
-      console.log('ancestorInstances', ancestorInstances)
-
-      // 先祖インスタンスがある場合 (nodeはインスタンスの子要素)
-      if (ancestorInstances.length > 0) {
-        // componentPropertyReferences.charactersがある場合
-        if (textNode.componentPropertyReferences?.characters) {
-          // 一番近い先祖インスタンスの取得 (ancestorInstancesの最後の要素)
-          const ancestorInstance =
-            ancestorInstances[ancestorInstances.length - 1]
-
-          // プロパティ名を取得
-          const propertyName = textNode.componentPropertyReferences.characters
-
-          // 先祖インスタンスの該当componentPropertyにVariableを割り当て
-          ancestorInstance.setProperties({
-            [propertyName]: {
-              type: 'VARIABLE_ALIAS',
-              id: targetVariable.id,
-            },
-          })
-        } else {
-          // ない場合、textNodeにVariableを割り当て
-          textNode.setBoundVariable('characters', targetVariable)
-        }
-      } else {
-        // 先祖インスタンスが無い場合、単純にtextNodeにVariableを割り当て
-        textNode.setBoundVariable('characters', targetVariable)
-      }
+      await applyVariableToTextNode(textNode, targetVariable)
     }),
   )
 }

--- a/src/main/applyVariable.ts
+++ b/src/main/applyVariable.ts
@@ -1,4 +1,4 @@
-import { emit } from '@create-figma-plugin/utilities'
+import { getAncestorInstances } from '@/main/util'
 
 export default async function applyVariable(variable: VariableForUI) {
   console.log('applyVariable', applyVariable)
@@ -41,8 +41,36 @@ export default async function applyVariable(variable: VariableForUI) {
         return
       }
 
-      // textNodeにVariableを割り当て
-      textNode.setBoundVariable('characters', targetVariable)
+      // 先祖インスタンスを取得
+      const ancestorInstances = await getAncestorInstances(textNode)
+      console.log('ancestorInstances', ancestorInstances)
+
+      // 先祖インスタンスがある場合 (nodeはインスタンスの子要素)
+      if (ancestorInstances.length > 0) {
+        // componentPropertyReferences.charactersがある場合
+        if (textNode.componentPropertyReferences?.characters) {
+          // 一番近い先祖インスタンスの取得 (ancestorInstancesの最後の要素)
+          const ancestorInstance =
+            ancestorInstances[ancestorInstances.length - 1]
+
+          // プロパティ名を取得
+          const propertyName = textNode.componentPropertyReferences.characters
+
+          // 先祖インスタンスの該当componentPropertyにVariableを割り当て
+          ancestorInstance.setProperties({
+            [propertyName]: {
+              type: 'VARIABLE_ALIAS',
+              id: targetVariable.id,
+            },
+          })
+        } else {
+          // ない場合、textNodeにVariableを割り当て
+          textNode.setBoundVariable('characters', targetVariable)
+        }
+      } else {
+        // 先祖インスタンスが無い場合、単純にtextNodeにVariableを割り当て
+        textNode.setBoundVariable('characters', targetVariable)
+      }
     }),
   )
 }

--- a/src/main/applyVariableToTextNode.ts
+++ b/src/main/applyVariableToTextNode.ts
@@ -1,0 +1,35 @@
+import { getAncestorInstances } from '@/main/util'
+
+export async function applyVariableToTextNode(
+  node: TextNode,
+  variable: Variable,
+): Promise<void> {
+  // 先祖インスタンスを取得
+  const ancestorInstances = await getAncestorInstances(node)
+
+  // 先祖インスタンスがある場合 (nodeはインスタンスの子要素)
+  if (ancestorInstances.length > 0) {
+    // componentPropertyReferences.charactersがある場合
+    if (node.componentPropertyReferences?.characters) {
+      // 一番近い先祖インスタンスの取得 (ancestorInstancesの最後の要素)
+      const ancestorInstance = ancestorInstances[ancestorInstances.length - 1]
+
+      // プロパティ名を取得
+      const propertyName = node.componentPropertyReferences.characters
+
+      // 先祖インスタンスの該当componentPropertyにVariableを割り当て
+      ancestorInstance.setProperties({
+        [propertyName]: {
+          type: 'VARIABLE_ALIAS',
+          id: variable.id,
+        },
+      })
+    } else {
+      // ない場合、nodeにVariableを割り当て
+      node.setBoundVariable('characters', variable)
+    }
+  } else {
+    // 先祖インスタンスが無い場合、単純にnodeにVariableを割り当て
+    node.setBoundVariable('characters', variable)
+  }
+}

--- a/src/main/util.ts
+++ b/src/main/util.ts
@@ -1,4 +1,3 @@
-import { emit } from '@create-figma-plugin/utilities'
 import { times, uniqBy } from 'es-toolkit/compat'
 
 // nodeの親がコンポーネント or Variantsかどうかを返す再帰関数
@@ -24,15 +23,14 @@ export function getIsNodeParentComponentOrVariants(node: SceneNode) {
 
 // nodeのidから先祖インスタンスの配列を返す関数（自分は含まない）
 export async function getAncestorInstances(node: SceneNode) {
-  const instanceArray: InstanceNode[] = []
-
   // idをセミコロンで区切って配列にしたもの
   const idArray = node.id.split(';')
 
   // 非同期処理を並列実行するためのPromise配列を生成
-  const promises = idArray.map(async (id, i) => {
+  // 各Promiseはインスタンスノードまたはnullを解決する
+  const promises = idArray.map(async (id, i): Promise<InstanceNode | null> => {
     // 最後のidは除外
-    if (i === idArray.length - 1) return
+    if (i === idArray.length - 1) return null
 
     // indexに応じてidを加工
     const targetId =
@@ -46,15 +44,24 @@ export async function getAncestorInstances(node: SceneNode) {
       // 加工したidを元にインスタンスを検索
       const instance = await figma.getNodeByIdAsync(targetId)
       if (instance && instance.type === 'INSTANCE') {
-        instanceArray.push(instance as InstanceNode)
+        // インスタンスが見つかった場合はそれを返す
+        return instance as InstanceNode
       }
     } catch (error) {
       console.error(`Failed to get instance with id: ${targetId}`, error)
     }
+    // インスタンスが見つからない、またはエラーが発生した場合はnullを返す
+    return null
   })
 
   // すべての非同期処理が完了するのを待つ
-  await Promise.all(promises)
+  // results配列はpromises配列と同じ順序になる
+  const results = await Promise.all(promises)
+
+  // 結果配列からnullを除外し、有効なインスタンスノードのみをフィルタリングする
+  const instanceArray = results.filter(
+    (instance): instance is InstanceNode => instance !== null,
+  )
 
   return instanceArray
 }

--- a/src/main/util.ts
+++ b/src/main/util.ts
@@ -80,7 +80,7 @@ export async function getTextNodes(targetTextRange: TargetTextRange) {
       // ページを読み込む
       await page.loadAsync()
 
-      // ページは以下にあるすべてのテキストをtextNodesに追加
+      // ページ配下にあるすべてのテキストをtextNodesに追加
       textNodes = [
         ...textNodes,
         ...page.findAllWithCriteria({ types: ['TEXT'] }),


### PR DESCRIPTION
- When a component has a text property set, and you're trying to assign a variable to the text within an instance, the variable will now be applied to the instance’s text property instead of directly to the text itself.
- Similarly, for the highlight text feature, even if a variable isn’t directly applied to the text, it will now be highlighted in blue if the instance’s text property is assigned a variable.

---

- [Refactor applyVariable to utilize getAncestorInstances for improved v…](https://github.com/ryonakae/figma-plugin-sync-variables-with-notion/commit/26ba959fa8607b36ba764e069b5ee58c2572a56c) 
- [applyVariable関数をリファクタリングし、applyVariableToTextNodeを使用してテキストノードへの変数割り当て…](https://github.com/ryonakae/figma-plugin-sync-variables-with-notion/commit/cf255d8722f8a686c86fb678d469ad7720c0c638) 
- [highlightText関数で先祖インスタンスを取得し、変数の割り当てを改善。getTextNodes関数のコメントを修正。](https://github.com/ryonakae/figma-plugin-sync-variables-with-notion/commit/e41a6c42cadd993703847eee93349aedb9ad1400)